### PR TITLE
Support for internet access when using "create-networking" & security group tweaks

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -21,3 +21,18 @@ resource "aws_subnet" "avi" {
     ignore_changes = [tags]
   }
 }
+
+resource "aws_internet_gateway" "avi" {
+  count                   = var.create_networking ? 1 : 0
+  vpc_id                  = aws_vpc.avi[0].id
+  tags = {
+    Name = "${var.name_prefix}-avi-igw"
+  }
+}
+
+resource "aws_route" "default_route" {
+  count                   = var.create_networking ? 1 : 0
+  route_table_id          = aws_vpc.avi[0].main_route_table_id
+  destination_cidr_block  = "0.0.0.0/0"
+  gateway_id              = aws_internet_gateway.avi[0].id
+}

--- a/security.tf
+++ b/security.tf
@@ -69,26 +69,33 @@ resource "aws_security_group" "avi_se_mgmt_sg" {
     protocol    = "icmp"
     cidr_blocks = [var.avi_cidr_block]
   }
-  egress {
-    description = "Allow SSH to Controller"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
+  ingress {
+    description = "ETHERIP to SE"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "97"
+    cidr_blocks = [var.avi_cidr_block]
+  }
+  ingress {
+    description = "CPHB to SE"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "73"
+    cidr_blocks = [var.avi_cidr_block]
+  }
+  ingress {
+    description = "Proto63 to SE"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "63"
     cidr_blocks = [var.avi_cidr_block]
   }
   egress {
-    description = "Allow 8443 to Controller"
-    from_port   = 8443
-    to_port     = 8443
-    protocol    = "tcp"
-    cidr_blocks = [var.avi_cidr_block]
-  }
-  egress {
-    description = "Allow NTP to Controller"
-    from_port   = 123
-    to_port     = 123
-    protocol    = "udp"
-    cidr_blocks = [var.avi_cidr_block]
+    description = "Allow any Outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
   tags = {
     Name = "${var.name_prefix}-avi-se-mgmt-sg"
@@ -106,12 +113,26 @@ resource "aws_security_group" "avi_data_sg" {
     protocol    = "-1"
     cidr_blocks = [var.avi_cidr_block]
   }
+  ingress{
+    description = "HTTPS Inbound"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress{
+    description = "HTTP Inbound"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
   egress {
-    description = "Allow Traffic to VPC"
+    description = "Allow Traffic Outbound"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [var.avi_cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
   tags = {
     Name = "${var.name_prefix}-avi-data-sg"

--- a/security.tf
+++ b/security.tf
@@ -91,11 +91,25 @@ resource "aws_security_group" "avi_se_mgmt_sg" {
     cidr_blocks = [var.avi_cidr_block]
   }
   egress {
-    description = "Allow any Outbound"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow SSH to Controller"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.avi_cidr_block]
+  }
+  egress {
+    description = "Allow 8443 to Controller"
+    from_port   = 8443
+    to_port     = 8443
+    protocol    = "tcp"
+    cidr_blocks = [var.avi_cidr_block]
+  }
+  egress {
+    description = "Allow NTP to Controller"
+    from_port   = 123
+    to_port     = 123
+    protocol    = "udp"
+    cidr_blocks = [var.avi_cidr_block]
   }
   tags = {
     Name = "${var.name_prefix}-avi-se-mgmt-sg"


### PR DESCRIPTION
The IGW changes are pretty straightforward - let me know if you have any questions or feedback there.

For security groups:

se-mgmt:  I found that when an SE is first created, it requires the original se-mgmt inbound SG ports included in the initial commit. However, once a VS is created and needs to be assigned to an SE, the additional protocols that are added here become necessary.

se-data:
- Changed outbound to allow access outside of the VPC, as there may be pool members that exist outside of the VPC.
- Allowed HTTP/HTTPS inbound, as these are the most likely ports to be used in a POC, and keeps with terraform provisioning the SGs for SE-Data (we discussed the drawbacks of allowing the controller to manage).